### PR TITLE
Turn broken ice into air

### DIFF
--- a/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
+++ b/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
@@ -127,8 +127,11 @@ public class SafeBucketsListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerBucketFill(PlayerBucketFillEvent event) {
-        Block block = event.getBlockClicked().getRelative(event.getBlockFace());
-        plugin.removeSafeLiquidFromCacheAndDB(block);
-        //plugin.table.removeSafeLiquid(block);
+        Material mat = event.getItemStack().getType();
+        if (mat == Material.LAVA_BUCKET || mat == Material.WATER_BUCKET) {
+            Block block = event.getBlockClicked().getRelative(event.getBlockFace());
+            plugin.removeSafeLiquidFromCacheAndDB(block);
+            //plugin.table.removeSafeLiquid(block);
+        }
     }
 }


### PR DESCRIPTION
It seems BlockFade event does not cover the ice block being broken by hand, so we need to handle that somehow. 

This is untested currently, logically it may impact silk touch picks no longer being able to pick up water.
