### PR TITLE
Fix unsafe buckets, fix dispenser handing and improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target/
 *.iml
 .idea/
+
+# Eclipse:
+.classpath
+.project

--- a/README.md
+++ b/README.md
@@ -1,7 +1,39 @@
 SafeBuckets
 ===========
+SafeBuckets prevents flowing and physics events from affecting bucket-placed
+liquids, so that player-placed water and lava never flow. SafeBuckets doesn't
+interfere with blocks placed with actual liquid blocks, so people with access
+to those them can still add normal flowing liquids.
 
-Prevents flowing and physics events from affecting bucket-placed fluids, so
-that player-placed water and lava never flow. Doesn't catch blocks placed with
-actual fluid blocks, so people with access to place them can still add normal
-water.
+In this documentation, non-flowing liquids are referred to as "safe", whereas
+flowing liquids are "unsafe".
+
+
+Inspector Item and Block
+------------------------
+SafeBuckets supports the use of both a configurable item and a configurable
+block to query or toggle liquid flow.  By default, these inspector tools are
+a blaze rod and a lapis ore block, respectively.  In order to use the inspector
+tool item or block, you must have the "safebuckets.tools.item" or
+"safebuckets.tools.block" permissions, respectively.
+
+Left-clicking with a tool will toggle flow on or off at a location.  Right-
+clicking will merely query whether the location has liquid flow enabled.
+
+The location selected by the inspector tool block is different from that
+selected by the tool item.  Whereas the inspector tool item queries or toggles
+the block you click on, the inspector tool block queries the block *adjacent*
+to the particular side of the block you click on.  When left-clicking on a
+block with the inspector tool block, bear in mind that the block toggled is
+not the one you are *punching*, but the *hole* that would be filled if you
+were placing a block by right-clicking.
+
+
+Dispenser Handling
+------------------
+If the plugin is configured for safe dispensers (the default) then they will
+dispense non-flowing liquids, when first placed.  Dispensers can be toggled
+between dispensing safe and unsafe liquids by left-clicking on them with the
+inspector tool item.  It is *not* necessary to enable flow of the dispensed
+liquid block; SafeBuckets will do that itself if the dispenser is set to unsafe.
+

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>SafeBuckets</groupId>
 	<artifactId>SafeBuckets</artifactId>
-	<version>0.7.3</version>
+	<version>0.7.4</version>
 	<packaging>jar</packaging>
 	<name>SafeBuckets</name>
     <description>Make water non-flowing for water from buckets</description>

--- a/src/nu/nerd/SafeBuckets/SafeBuckets.java
+++ b/src/nu/nerd/SafeBuckets/SafeBuckets.java
@@ -165,7 +165,7 @@ public class SafeBuckets extends JavaPlugin {
 	public boolean isUnsafeBucket(ItemStack item) {
 		if (item.getType().equals(Material.WATER_BUCKET) || item.getType().equals(Material.LAVA_BUCKET))
 			return EnchantGlow.hasGlow(item);
-		
+
 		return false;
 	}
 
@@ -186,6 +186,10 @@ public class SafeBuckets extends JavaPlugin {
         table = new SafeLiquidTable(this);
 
         log.log(Level.INFO, "[" + getDescription().getName() + "] " + getDescription().getVersion() + " enabled.");
+
+        // Cause the GLOW enchantment to come into being right now, for
+        // compatibility with ModMode item serialization.
+        EnchantGlow.getGlow();
     }
 
     public boolean setupDatabase() {
@@ -214,21 +218,21 @@ public class SafeBuckets extends JavaPlugin {
         table.queueAdd.add(stat);
         addSafeLiquidToCache(stat);
     }
-    
+
     public void removeSafeLiquidFromCacheAndDB(Block block) {
         String world = block.getWorld().getName();
         Long l = Util.GetHashCode(block.getX(), block.getY(), block.getZ());
         if (cachedSafeBlocks.containsKey(world)) {
             cachedSafeBlocks.get(world).remove(l);
         }
-        
+
         table.removeSafeLiquid(block);
     }
-    
+
     public boolean isSafeLiquid(Block block) {
         String world = block.getWorld().getName();
         Long l = Util.GetHashCode(block.getX(), block.getY(), block.getZ());
-        
+
         if (cachedSafeBlocks.containsKey(world)) {
             return cachedSafeBlocks.get(world).contains(l);
         }

--- a/src/nu/nerd/SafeBuckets/SafeBuckets.java
+++ b/src/nu/nerd/SafeBuckets/SafeBuckets.java
@@ -12,10 +12,11 @@ import javax.persistence.PersistenceException;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.selections.CuboidSelection;
 import com.sk89q.worldedit.bukkit.selections.Selection;
-import me.sothatsit.usefulsnippets.EnchantGlow;
 
+import me.sothatsit.usefulsnippets.EnchantGlow;
 import nu.nerd.SafeBuckets.database.SafeLiquid;
 import nu.nerd.SafeBuckets.database.SafeLiquidTable;
+
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.command.Command;
@@ -23,12 +24,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitScheduler;
 
 public class SafeBuckets extends JavaPlugin {
 
@@ -190,6 +188,16 @@ public class SafeBuckets extends JavaPlugin {
         // Cause the GLOW enchantment to come into being right now, for
         // compatibility with ModMode item serialization.
         EnchantGlow.getGlow();
+    }
+
+    public void debug(String message) {
+        if (getConfig().getBoolean("debug.players")) {
+            getServer().broadcast(message, "safebuckets.debug");
+        }
+
+        if (getConfig().getBoolean("debug.console")) {
+            log.info(message);
+        }
     }
 
     public boolean setupDatabase() {

--- a/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
+++ b/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
@@ -49,7 +49,7 @@ public class SafeBucketsListener implements Listener {
 
 	        if ((mat == Material.LAVA_BUCKET || mat == Material.WATER_BUCKET)) {
 	        	if (plugin.getConfig().getBoolean("dispenser.enabled")) {
-		        	if (plugin.getConfig().getBoolean("bucket.safe") && plugin.isSafeLiquid(blockDispenser))
+                    if (plugin.getConfig().getBoolean("dispenser.safe") && plugin.isSafeLiquid(blockDispenser))
 		        		plugin.addBlockToCacheAndDB(blockDispense);
 
 		        	String message = "SafeBuckets: Dispensing (" + event.getBlock().getX() + ", " + event.getBlock().getY() + ", " + event.getBlock().getZ() + ") ";
@@ -97,13 +97,13 @@ public class SafeBucketsListener implements Listener {
             event.setCancelled(true);
         }
     }
-    
+
     // Stop all ice melting, putting every melted ice block in the database would very quickly fill it to excessive sizes
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockFade(BlockFadeEvent event) {
         if (event.getBlock().getType() == Material.ICE) {
             event.setCancelled(true);
-        } 
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
+++ b/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
@@ -1,6 +1,8 @@
 package nu.nerd.SafeBuckets;
 
 import me.sothatsit.usefulsnippets.EnchantGlow;
+
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
@@ -25,8 +27,15 @@ public class SafeBucketsListener implements Listener {
 
     private final SafeBuckets plugin;
 
+    // Cache tool item and block materials since they are accessed every
+    // PlayerInteractEvent.
+    private final Material TOOL_ITEM_MATERIAL;
+    private final Material TOOL_BLOCK_MATERIAL;
+
     SafeBucketsListener(SafeBuckets instance) {
         plugin = instance;
+        TOOL_ITEM_MATERIAL = Material.getMaterial(plugin.getConfig().getString("tool.item"));
+        TOOL_BLOCK_MATERIAL = Material.getMaterial(plugin.getConfig().getString("tool.block"));
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -45,35 +54,34 @@ public class SafeBucketsListener implements Listener {
 	        Material mat = event.getItem().getType();
 	        Dispenser dispenser = (Dispenser)event.getBlock().getState().getData();
 	    	Block blockDispenser = event.getBlock();
-	    	Block blockDispense = blockDispenser.getRelative(dispenser.getFacing());
+            Block blockDispensed = blockDispenser.getRelative(dispenser.getFacing());
 
-	        if ((mat == Material.LAVA_BUCKET || mat == Material.WATER_BUCKET)) {
-	        	if (plugin.getConfig().getBoolean("dispenser.enabled")) {
-                    if (plugin.getConfig().getBoolean("dispenser.safe") && plugin.isSafeLiquid(blockDispenser))
-		        		plugin.addBlockToCacheAndDB(blockDispense);
+	        if (mat == Material.LAVA_BUCKET || mat == Material.WATER_BUCKET) {
+                if (plugin.getConfig().getBoolean("dispenser.enabled")) {
+                    if (plugin.getConfig().getBoolean("dispenser.safe") && plugin.isSafeLiquid(blockDispenser)) {
+                        plugin.addBlockToCacheAndDB(blockDispensed);
+                    }
 
-		        	String message = "SafeBuckets: Dispensing (" + event.getBlock().getX() + ", " + event.getBlock().getY() + ", " + event.getBlock().getZ() + ") ";
-		        	if (!plugin.isSafeLiquid(blockDispenser))
-		        		message += "un";
-		        	message += "safe";
-
-	        		if (plugin.getConfig().getBoolean("debug.players")) {
-	        			plugin.getServer().broadcast(message, "safebuckets.debug");
-	        		}
-
-	        		if (plugin.getConfig().getBoolean("debug.console")) {
-	        			SafeBuckets.log.info(message);
-	        		}
+                    plugin.debug("SafeBuckets: Dispense " + Util.formatCoords(event.getBlock()) + (plugin.isSafeLiquid(event.getBlock()) ? " safe" : " unsafe"));
 	        	} else {
 	        		event.setCancelled(true);
 	        	}
+	        } else if (mat == Material.BUCKET) {
+                if (blockDispensed.getType() == Material.WATER || blockDispensed.getType() == Material.STATIONARY_WATER ||
+                    blockDispensed.getType() == Material.LAVA  || blockDispensed.getType() == Material.STATIONARY_LAVA) {
+                    // Empty bucket taking liquid.
+                    if (plugin.getConfig().getBoolean("dispenser.enabled")) {
+                        // Regardless of whether the dispenser is safe or unsafe, when liquid in front of it
+                        // is removed from the world, it is removed from the DB (i.e. made to flow) too.
+                        plugin.removeSafeLiquidFromCacheAndDB(blockDispensed);
+
+                        plugin.debug("SafeBuckets: Un-Dispense " + Util.formatCoords(event.getBlock()) + (plugin.isSafeLiquid(event.getBlock()) ? " safe" : " unsafe"));
+                    } else {
+                        event.setCancelled(true);
+                    }
+                }
 	        }
 		}
-    	else if (event.getBlock().getType() == Material.WATER || event.getBlock().getType() == Material.STATIONARY_WATER || event.getBlock().getType() == Material.LAVA || event.getBlock().getType() == Material.STATIONARY_LAVA) {
-        	if (plugin.isSafeLiquid(event.getBlock())) {
-                plugin.removeSafeLiquidFromCacheAndDB(event.getBlock());
-        	}
-    	}
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -166,47 +174,33 @@ public class SafeBucketsListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
-    	Player player = event.getPlayer();
+        Player player = event.getPlayer();
+        if (event.getAction() == Action.LEFT_CLICK_BLOCK || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            if (event.hasItem() && event.getItem().getType() == TOOL_ITEM_MATERIAL && player.hasPermission("safebuckets.tools.item")) {
+                useTool(event, event.getClickedBlock());
+            } else if (event.isBlockInHand() && event.getItem().getType() == TOOL_BLOCK_MATERIAL && player.hasPermission("safebuckets.tools.block")) {
+                useTool(event, event.getClickedBlock().getRelative(event.getBlockFace()));
+            }
+        }
+    }
 
-    	if (event.isBlockInHand() && event.getItem().getType() == Material.getMaterial(plugin.getConfig().getString("tool.block")) && player.hasPermission("safebuckets.tools.block") && event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-    		Block block = event.getClickedBlock().getRelative(event.getBlockFace()).getLocation().getBlock();
-    		if (plugin.isSafeLiquid(block)) {
-    			player.sendMessage("SafeBuckets: (X=" + block.getX() + ", Z=" + block.getZ() + ", Y=" + block.getY() + ") safe");
-    		} else {
-    			player.sendMessage("SafeBuckets: (X=" + block.getX() + ", Z=" + block.getZ() + ", Y=" + block.getY() + ") unsafe");
-    		}
-    		event.setCancelled(true);
-    	}
-    	else if (event.isBlockInHand() && event.getItem().getType() == Material.getMaterial(plugin.getConfig().getString("tool.block")) && player.hasPermission("safebuckets.tools.block") && event.getAction() == Action.LEFT_CLICK_BLOCK) {
-    		Block block = event.getClickedBlock().getRelative(event.getBlockFace()).getLocation().getBlock();
-    		if (plugin.isSafeLiquid(block)) {
-    			player.sendMessage("SafeBuckets: (X=" + block.getX() + ", Z=" + block.getZ() + ", Y=" + block.getY() + ") removed safe");
-                plugin.removeSafeLiquidFromCacheAndDB(block);
-    		} else {
-    			player.sendMessage("SafeBuckets: (X=" + block.getX() + ", Z=" + block.getZ() + ", Y=" + block.getY() + ") set safe");
+    private void useTool(PlayerInteractEvent event, Block block) {
+        event.setCancelled(true);
+
+        boolean isSafe = plugin.isSafeLiquid(block);
+        boolean toggleFlow = (event.getAction() == Action.LEFT_CLICK_BLOCK);
+        if (toggleFlow) {
+            isSafe = !isSafe;
+            if (isSafe) {
                 plugin.addBlockToCacheAndDB(block);
-    		}
-    		event.setCancelled(true);
-    	}
-    	else if (event.hasItem() && event.getItem().getType() == Material.getMaterial(plugin.getConfig().getString("tool.item")) && player.hasPermission("safebuckets.tools.item") && event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-    		Block block = event.getClickedBlock();
-    		if (plugin.isSafeLiquid(block)) {
-    			player.sendMessage("SafeBuckets: (X=" + block.getX() + ", Z=" + block.getZ() + ", Y=" + block.getY() + ") safe");
-    		} else {
-    			player.sendMessage("SafeBuckets: (X=" + block.getX() + ", Z=" + block.getZ() + ", Y=" + block.getY() + ") unsafe");
-    		}
-    		event.setCancelled(true);
-    	}
-    	else if (event.hasItem() && event.getItem().getType() == Material.getMaterial(plugin.getConfig().getString("tool.item")) && player.hasPermission("safebuckets.tools.item") && event.getAction() == Action.LEFT_CLICK_BLOCK) {
-    		Block block = event.getClickedBlock();
-    		if (plugin.isSafeLiquid(block)) {
-    			player.sendMessage("SafeBuckets: (X=" + block.getX() + ", Z=" + block.getZ() + ", Y=" + block.getY() + ") removed safe");
+            } else {
                 plugin.removeSafeLiquidFromCacheAndDB(block);
-    		} else {
-    			player.sendMessage("SafeBuckets: (X=" + block.getX() + ", Z=" + block.getZ() + ", Y=" + block.getY() + ") set safe");
-                plugin.addBlockToCacheAndDB(block);
-    		}
-    		event.setCancelled(true);
-    	}
+            }
+        }
+        String format = toggleFlow ? "&dSafeBuckets toggle: %s is now %s&d."
+                                   : "&dSafeBuckets query: %s is %s&d.";
+        String coords = Util.formatCoords(block);
+        String safeness = isSafe ? "&asafe" : "&cunsafe";
+        event.getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&', String.format(format, coords, safeness)));
     }
 }

--- a/src/nu/nerd/SafeBuckets/Util.java
+++ b/src/nu/nerd/SafeBuckets/Util.java
@@ -1,5 +1,7 @@
 package nu.nerd.SafeBuckets;
 
+import org.bukkit.block.Block;
+
 public class Util {
     private static long FixXZ(int n)
     {
@@ -9,6 +11,14 @@ public class Util {
     public static long GetHashCode(int x, int y, int z)
     {
         return (FixXZ(x) << 28) | (((long)y & 0xff) << 56) | FixXZ(z);
+    }
+
+    public static String formatCoords(Block block) {
+        return formatCoords(block.getWorld().getName(), block.getX(), block.getY(), block.getZ());
+    }
+
+    public static String formatCoords(String world, int x, int y, int z) {
+        return  "(" + world + ", " + x + ", " + y + ", " + z + ")";
     }
 
     /* not used right now but keeping around for future reference


### PR DESCRIPTION
This pull fixes two issues:

 * Unsafe buckets turning into safe buckets.
 * Dispensers marked as unsafe dispensing safe liquids anyway.

In the past, to make a dispenser dispense unsafe liquid, you had to mark both the dispenser and the location of the dispensed liquid as unsafe.  The new code just requires that the dispenser is unsafe; it then "does the right thing".

The documentation clarifies the use of the inspector tool item and tool block.  The tool block is fairly confusing: it will always operate on the block *adjacent to* whatever side of the block you click on.  This is confusing because when you left click with the inspector tool block, the clicked block briefly disappears (a cancelled block break), making you think you are querying that block.

I would argue that the tool item is now sufficiently easy to use that it can be enabled for use by moderators by giving the ModMode group the safebuckets.tools.item permission.  Moderators can then handle ModReqs concerning dispenser flow.

I would also argue that the inspector tool block (lapis ore) is redundant (except for checking the safety of already placed liquids), confusing (despite my best attempts to explain it) and takes away admins' ability to build with lapis ore, and that therefore they would be better off not having the safebuckets.tools.block permission.
