### PR TITLE
Allow moderators to interact with locked dispensers.

### DIFF
--- a/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
+++ b/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
@@ -172,7 +172,7 @@ public class SafeBucketsListener implements Listener {
         }
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
         if (event.getAction() == Action.LEFT_CLICK_BLOCK || event.getAction() == Action.RIGHT_CLICK_BLOCK) {


### PR DESCRIPTION
Handle interaction first, before LWC, so that moderators can interact with locked dispensers.  Without this, it is not possible for mods to make dispenser flow work.