### PR TITLE
Fix dispensers and bubble columns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>SafeBuckets</groupId>
     <artifactId>SafeBuckets</artifactId>
-    <version>1.1.19</version>
+    <version>1.1.20</version>
     <packaging>jar</packaging>
     <name>SafeBuckets</name>
     <description>Make water non-flowing for water from buckets</description>

--- a/src/nu/nerd/SafeBuckets/Commands.java
+++ b/src/nu/nerd/SafeBuckets/Commands.java
@@ -317,7 +317,7 @@ public class Commands implements TabExecutor {
             for (int y = min.getBlockY(); y <= max.getBlockY(); y++) {
                 for (int z = min.getBlockZ(); z <= max.getBlockZ(); z++) {
                     Block block = world.getBlockAt(x, y, z);
-                    if (block.getType() == Material.WATER || block.getType() == Material.LAVA || Util.isWaterlogged(block)) {
+                    if (block.getType() == Material.BUBBLE_COLUMN || block.getType() == Material.WATER || block.getType() == Material.LAVA || Util.isWaterlogged(block)) {
                         if (state && block.getBlockData() instanceof Levelled) {
                             Levelled levelled = (Levelled) block.getBlockData();
                             if (levelled.getLevel() > 0) {

--- a/src/nu/nerd/SafeBuckets/SafeBuckets.java
+++ b/src/nu/nerd/SafeBuckets/SafeBuckets.java
@@ -127,9 +127,7 @@ public class SafeBuckets extends JavaPlugin {
             BlockStoreApi.setBlockMeta(block, PLUGIN, METADATA_KEY, true);
         } else {
             CACHE.remove(block.getLocation());
-            BlockStoreApi.getAllBlockMeta(block, PLUGIN).forEach((key, o) -> {
-                BlockStoreApi.removeBlockMeta(block, PLUGIN, key);
-            });
+            BlockStoreApi.removeBlockMeta(block, PLUGIN, METADATA_KEY);
         }
 
         // force block updates (note: can be simplified once Spigot adds new block update method

--- a/src/nu/nerd/SafeBuckets/SafeBuckets.java
+++ b/src/nu/nerd/SafeBuckets/SafeBuckets.java
@@ -15,6 +15,9 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Levelled;
+import org.bukkit.block.data.type.BubbleColumn;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -115,29 +118,50 @@ public class SafeBuckets extends JavaPlugin {
      * in the internal cache and BlockStore.
      *
      * @param block the block.
-     * @param state the safety status (true = safe).
+     * @param safe the safety status (true = safe).
      */
-    static void setSafe(Block block, boolean state) {
-        Bukkit.getScheduler().runTaskLater(PLUGIN, () -> {
-            if (state) {
-                sendDebugMessage("Safety change: " + Util.formatCoords(block.getLocation()) + " has been made §aSAFE");
-                CACHE.add(block.getLocation());
-            } else {
-                sendDebugMessage("Safety change: " + Util.formatCoords(block.getLocation()) + " has been made §cUNSAFE");
-                CACHE.remove(block.getLocation());
-            }
+    static void setSafe(Block block, boolean safe) {
+        // update blockstore
+        if (safe) {
+            CACHE.add(block.getLocation());
+            BlockStoreApi.setBlockMeta(block, PLUGIN, METADATA_KEY, true);
+        } else {
+            CACHE.remove(block.getLocation());
+            BlockStoreApi.getAllBlockMeta(block, PLUGIN).forEach((key, o) -> {
+                BlockStoreApi.removeBlockMeta(block, PLUGIN, key);
+            });
+        }
 
-            // check if there's an entry before spawning particles
-            if (CONFIG.SHOW_PARTICLES && BlockStoreApi.getBlockMeta(block, PLUGIN, METADATA_KEY) != null) {
-                Bukkit.getScheduler().runTaskLaterAsynchronously(PLUGIN, () -> Util.showParticles(block, state), 1);
+        // force block updates (note: can be simplified once Spigot adds new block update method
+        // see: https://hub.spigotmc.org/jira/browse/SPIGOT-4759
+        if (!safe) {
+            if (block.getType() == Material.BUBBLE_COLUMN) {
+                final boolean isDrag = ((BubbleColumn) block.getBlockData()).isDrag();
+                block.setType(Material.WATER, true);
+                Bukkit.getScheduler().runTask(PLUGIN, () -> {
+                    block.setType(Material.BUBBLE_COLUMN, true);
+                    ((BubbleColumn) block.getBlockData()).setDrag(isDrag);
+                });
+            } else if (block.getType() == Material.WATER || block.getType() == Material.LAVA) {
+                Levelled levelled = (Levelled) block.getBlockData();
+                levelled.setLevel(1);
+                block.setBlockData(levelled);
+                Bukkit.getScheduler().runTask(PLUGIN, () -> {
+                    levelled.setLevel(0);
+                    block.setBlockData(levelled);
+                });
+            } else if (Util.isWaterlogged(block)) {
+                for (BlockFace blockFace : Util.ADJACENT_BLOCK_FACES) {
+                    Block adjacentBlock = block.getRelative(blockFace);
+                    Material type = adjacentBlock.getType();
+                    if (type == Material.AIR || type == Material.CAVE_AIR) {
+                        adjacentBlock.setType(Material.VOID_AIR, true);
+                        Bukkit.getScheduler().runTask(PLUGIN, () -> adjacentBlock.setType(type));
+                        break;
+                    }
+                }
             }
-
-            BlockStoreApi.setBlockMeta(block, PLUGIN, METADATA_KEY, state);
-
-            if (!state) {
-                Util.forceBlockUpdate(block);
-            }
-        }, 1);
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
+++ b/src/nu/nerd/SafeBuckets/SafeBucketsListener.java
@@ -65,20 +65,20 @@ public class SafeBucketsListener implements Listener {
     public void onBlockDispense(BlockDispenseEvent event) {
         Material material = event.getItem().getType();
         Dispenser dispenser = (Dispenser) event.getBlock().getState().getData();
-        Block dispensed = event.getBlock().getRelative(dispenser.getFacing());
+        Block adjacentBlock = event.getBlock().getRelative(dispenser.getFacing());
 
         if (SafeBuckets.CONFIG.BUCKETS.contains(material)) { // filled bucket being dumped
             if (SafeBuckets.CONFIG.DISPENSERS_ENABLED) {
                 if (SafeBuckets.CONFIG.DISPENSERS_SAFE && SafeBuckets.isSafe(event.getBlock())) {
-                    SafeBuckets.setSafe(dispensed, true);
+                    SafeBuckets.setSafe(adjacentBlock, true);
                 }
             } else {
                 event.setCancelled(true);
             }
-        } else if (material == Material.BUCKET) { // empty bucket picking up liquid block
-            if (SafeBuckets.CONFIG.LIQUID_BLOCKS.contains(dispensed.getType())) {
+        } else if (material == Material.BUCKET) { // empty bucket picking up liquid block or a waterloggable
+            if (Util.isWaterlogged(adjacentBlock) || SafeBuckets.CONFIG.LIQUID_BLOCKS.contains(adjacentBlock.getType())) {
                 if (SafeBuckets.CONFIG.DISPENSERS_ENABLED) {
-                    SafeBuckets.removeSafe(dispensed);
+                    SafeBuckets.removeSafe(adjacentBlock);
                 }
             } else {
                 event.setCancelled(true);

--- a/src/nu/nerd/SafeBuckets/Util.java
+++ b/src/nu/nerd/SafeBuckets/Util.java
@@ -196,7 +196,7 @@ class Util {
     /**
      * A set of BlockFaces directly adjacent to an abstract block.
      */
-    private static final HashSet<BlockFace> ADJACENT_BLOCK_FACES = new HashSet<>(Arrays.asList(
+    public static final HashSet<BlockFace> ADJACENT_BLOCK_FACES = new HashSet<>(Arrays.asList(
         BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN
     ));
 


### PR DESCRIPTION
Version 1.1.20.

Fixes two issues:

1. A dispenser containing an empty bucket cannot pick up water from a waterlogged block.
2. Bubble columns cannot be flowed / bubble columns do not form from a single flowed water source.

Also improves flow logic. See https://hub.spigotmc.org/jira/browse/SPIGOT-4759 for more information on why the jankiness is necessary.